### PR TITLE
Generate artefacts

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -4,7 +4,7 @@ lazy = true
 
     [[ACE1pack_test_files.download]]
     sha256 = "5416b14aa2356ce8a399102a45232e8c44e746c3270c4baa15d4bbcce9fcc2e7"
-    url = "https://github.com/gelzinyte/test_julia_artifacts/blob/main/ACE1pack_test_files.tar.gz?raw=true"
+    url = "https://github.com/ACEsuit/ACEData/blob/master/tests/ACE1pack_test_files.tar.gz?raw=true"
 
 [TiAl_tiny_dataset]
 git-tree-sha1 = "86fd99369720539181edb3f27e0a265ae0c696df"
@@ -12,4 +12,4 @@ lazy = true
 
     [[TiAl_tiny_dataset.download]]
     sha256 = "3b286227cbd705a7d6f1a695c2decacda9981be588bcc5ce288e479f9e60db5e"
-    url = "https://github.com/gelzinyte/test_julia_artifacts/blob/main/TiAl_tiny.tar.gz?raw=true"
+    url = "https://github.com/ACEsuit/ACEData/blob/master/trainingsets/TiAl_tiny.tar.gz?raw=true"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,15 +1,15 @@
 [ACE1pack_test_files]
-git-tree-sha1 = "9d1fb0860c2a0d48624d5e464aac825ab204542a"
+git-tree-sha1 = "6b47b035f06e56fa0ca5cd9b0fb976b7f03bd3ba"
 lazy = true
 
     [[ACE1pack_test_files.download]]
-    sha256 = "a10df3a0ed507b76291acd2e073bd8593a5aa7a1f4f8b78718a8adb6800ac294"
-    url = "https://github.com/gelzinyte/test_julia_artifacts/blob/main/ACE1pack_test_files.zip?raw=true"
+    sha256 = "5416b14aa2356ce8a399102a45232e8c44e746c3270c4baa15d4bbcce9fcc2e7"
+    url = "https://github.com/gelzinyte/test_julia_artifacts/blob/main/ACE1pack_test_files.tar.gz?raw=true"
 
 [TiAl_tiny_dataset]
-git-tree-sha1 = "4ed1c6b17027b0be0adabb73604d478364428a89"
+git-tree-sha1 = "86fd99369720539181edb3f27e0a265ae0c696df"
 lazy = true
 
     [[TiAl_tiny_dataset.download]]
-    sha256 = "5c5ddd4883d50d1f5ce8c6bacc36ec15ffd08d96be0b774fea7262db14e1ba25"
-    url = "https://github.com/gelzinyte/test_julia_artifacts/blob/main/TiAl_tiny.zip?raw=true"
+    sha256 = "3b286227cbd705a7d6f1a695c2decacda9981be588bcc5ce288e479f9e60db5e"
+    url = "https://github.com/gelzinyte/test_julia_artifacts/blob/main/TiAl_tiny.tar.gz?raw=true"

--- a/Project.toml
+++ b/Project.toml
@@ -7,14 +7,15 @@ version = "0.0.1"
 ACE1 = "e3f9bc04-086e-409a-ba78-e9769fe067bb"
 IPFitting = "3002bd4c-79e4-52ce-b924-91256dde4e52"
 JuLIP = "945c410c-986d-556a-acb1-167a618e0462"
+LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
 ACE1 = "0.9.1"
 IPFitting = "0.10"
-julia = "1.6"
 JuLIP = "0.11.4"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/scripts/generate_artifacts.jl
+++ b/scripts/generate_artifacts.jl
@@ -1,62 +1,24 @@
-
-using ACE1pack, Pkg
+using ACE1pack
+using ArtifactUtils
 using Pkg.Artifacts
-using SHA
-
-artifacts_toml = joinpath(pathof(ACE1pack)[1:end-16], "Artifacts.toml")
 
 
-function generate_artifact(label, tarname, url)
+function safe_add_artifact!(label, url, artifacts_toml)
     data_hash = artifact_hash(label, artifacts_toml)
-
     if data_hash == nothing || !artifact_exists(data_hash)
-        tarfile = download(url, @__DIR__() * "/" * tarname)
-        hash_ = create_artifact() do artifact_dir
-            cp(tarfile, joinpath(artifact_dir, tarname))
-        end
-        tarball_hash = archive_artifact(hash_, joinpath(tarfile))
-        bind_artifact!(artifacts_toml, label, hash_,
-                    download_info = [ (url, tarball_hash) ], lazy=true, force=true)
+        add_artifact!(artifacts_toml, label, url, lazy=true, force=true)
     end
 end
 
 
+artifacts_toml = joinpath(pathof(ACE1pack)[1:end-16], "Artifacts.toml")
 
 label = "TiAl_tiny_dataset"
-tarname = "TiAl_tiny.tar.gz"
-url = "https://github.com/gelzinyte/test_julia_artifacts/blob/main/$(tarname)?raw=true"
-generate_artifact(label, tarname, url)
+url = "https://github.com/gelzinyte/test_julia_artifacts/blob/main/TiAl_tiny.tar.gz?raw=true"
+safe_add_artifact!(label, url, artifacts_toml)
+
 
 label = "ACE1pack_test_files"
-tarname = "ACE1pack_test_files.tar.gz"
-url = "https://github.com/gelzinyte/test_julia_artifacts/blob/main/$(tarname)?raw=true"
-generate_artifact(label, tarname, url)
-
-
-#---
-# testing the artifacts
-
-using ACE1pack, Pkg
-using Pkg.Artifacts
-
-#---
-# mock training set
-
-tial_tar = joinpath(artifact"TiAl_tiny_dataset", "TiAl_tiny.tar.gz")
-run(`tar -xzvf $tial_tar`)
-tial = "TiAl_tiny.xyz"
-configs =  IPFitting.Data.read_xyz(tial;
-    energy_key = "energy",
-    force_key = "force",
-    virial_key = "virial")
-
-#---
-# test files
-
-test_files_tar = joinpath(artifact"ACE1pack_test_files", "ACE1pack_test_files.tar.gz")
-run(`tar -xzvf $test_files_tar`)
-
-errors_fname = "expected_fit_errors.json"
-errors_dict = load_dict(errors_fname)
-
+url = "https://github.com/gelzinyte/test_julia_artifacts/blob/main/ACE1pack_test_files.tar.gz?raw=true"
+safe_add_artifact!(label, url, artifacts_toml)
 

--- a/scripts/generate_artifacts.jl
+++ b/scripts/generate_artifacts.jl
@@ -14,11 +14,11 @@ end
 artifacts_toml = joinpath(pathof(ACE1pack)[1:end-16], "Artifacts.toml")
 
 label = "TiAl_tiny_dataset"
-url = "https://github.com/gelzinyte/test_julia_artifacts/blob/main/TiAl_tiny.tar.gz?raw=true"
+url = "https://github.com/ACEsuit/ACEData/blob/master/trainingsets/TiAl_tiny.tar.gz?raw=true"
 safe_add_artifact!(label, url, artifacts_toml)
 
 
 label = "ACE1pack_test_files"
-url = "https://github.com/gelzinyte/test_julia_artifacts/blob/main/ACE1pack_test_files.tar.gz?raw=true"
+url = "https://github.com/ACEsuit/ACEData/blob/master/tests/ACE1pack_test_files.tar.gz?raw=true"
 safe_add_artifact!(label, url, artifacts_toml)
 

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -1,15 +1,29 @@
 
 using LazyArtifacts
 
-data_dir = joinpath(artifact"TiAl_tiny_dataset", "data")
-tests_files_dir = joinpath(artifact"ACE1pack_test_files", "files")
+# data_dir = joinpath(artifact"TiAl_tiny_dataset", "data")
+# tests_files_dir = joinpath(artifact"ACE1pack_test_files", "files")
 
-if !isfile(joinpath(data_dir, "TiAl_tiny.xyz"))
-    zip = joinpath(artifact"TiAl_tiny_dataset", "TiAl_tiny.zip")
-    run(`unzip $zip -d $data_dir`)
-end
+# if !isdir(data_dir)
+#     mkdir(data_dir)
+# end
 
-if !isfile(joinpath(tests_files_dir, "expected_fit_errors.json"))
-    zip = joinpath(artifact"ACE1pack_test_files", "ACE1pack_test_files.zip")
-    run(`unzip $zip -d $tests_files_dir`)
-end
+# if !isdir(tests_files_dir)
+#     mkdir(tests_files_dir)
+# end
+
+
+# if !isfile(joinpath(artifact"ACE1pack_test_files", "TiAl_tiny.xyz"))
+#     println("tarring things")
+#     tar = joinpath(artifact"TiAl_tiny_dataset", "TiAl_tiny.tar.gz")
+#     # run(`tar -xzvf $tar -C $data_dir`)
+#     run(`tar -xzvf $tar`)
+
+# end
+
+# # if !isfile(joinpath(tests_files_dir, "expected_fit_errors.json"))
+# if !isfile(joinpath(artifact"ACE1pack_test_files", "expected_fit_errors.json"))
+#     tar = joinpath(artifact"ACE1pack_test_files", "ACE1pack_test_files.tar.gz")
+#     # run(`tar -xzvf $tar -C $tests_files_dir`)
+#     run(`tar -xzvf $tar `)
+# end

--- a/test/artifacts.jl
+++ b/test/artifacts.jl
@@ -1,29 +1,2 @@
 
 using LazyArtifacts
-
-# data_dir = joinpath(artifact"TiAl_tiny_dataset", "data")
-# tests_files_dir = joinpath(artifact"ACE1pack_test_files", "files")
-
-# if !isdir(data_dir)
-#     mkdir(data_dir)
-# end
-
-# if !isdir(tests_files_dir)
-#     mkdir(tests_files_dir)
-# end
-
-
-# if !isfile(joinpath(artifact"ACE1pack_test_files", "TiAl_tiny.xyz"))
-#     println("tarring things")
-#     tar = joinpath(artifact"TiAl_tiny_dataset", "TiAl_tiny.tar.gz")
-#     # run(`tar -xzvf $tar -C $data_dir`)
-#     run(`tar -xzvf $tar`)
-
-# end
-
-# # if !isfile(joinpath(tests_files_dir, "expected_fit_errors.json"))
-# if !isfile(joinpath(artifact"ACE1pack_test_files", "expected_fit_errors.json"))
-#     tar = joinpath(artifact"ACE1pack_test_files", "ACE1pack_test_files.tar.gz")
-#     # run(`tar -xzvf $tar -C $tests_files_dir`)
-#     run(`tar -xzvf $tar `)
-# end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,16 +1,17 @@
-using ACE1pack
-using Test
+using ACE1pack, Test, LazyArtifacts
+
+##
 
 @testset "ACE1pack.jl" begin
 
-    include("test_data.jl")
+    @testset "Read data" begin include("test_data.jl") end 
 
-    include("test_basis.jl")
+    @testset "Basis" begin include("test_basis.jl") end 
 
-    include("test_solver.jl")
+    @testset "Solver" begin include("test_solver.jl") end 
 
-    include("test_fit.jl")
+    @testset "Fit ACE" begin include("test_fit.jl") end 
 
-    include("test_read_params.jl")
+    @testset "Read params" begin include("test_read_params.jl") end 
 
 end

--- a/test/test_basis.jl
+++ b/test/test_basis.jl
@@ -1,7 +1,7 @@
 
-@testset "Basis" begin
 
-using ACE1pack
+
+using ACE1pack, Test 
 
 @info("Test constructing rpi basis and parameters")
 rpi_basis = basis_params(type="rpi", species = :Si, N = 3, maxdeg = 10)
@@ -22,6 +22,3 @@ transform = ACE1pack.generate_transform(trans_params)
 @info("Test constructing radial basis parameters and rpi radial basis")
 rad_basis = basis_params(type="rad", rin = 0.0, pin = 0)
 ACE1pack.generate_rad_basis(rad_basis, D, 6, :Si, transform)
-
-
-end

--- a/test/test_data.jl
+++ b/test/test_data.jl
@@ -1,10 +1,11 @@
 
+include("artifacts.jl")
+
 @testset "Read data" begin
 
     using ACE1pack
 
-    include("artifacts.jl")
-    test_train_set = joinpath(data_dir, "TiAl_tiny.xyz")
+    test_train_set = joinpath(artifact"TiAl_tiny_dataset", "TiAl_tiny.xyz")
 
     @info("Test constructing `data_params` and reading data")
     params = data_params(fname = test_train_set, energy_key = "energy", force_key = "force", virial_key = "virial")

--- a/test/test_data.jl
+++ b/test/test_data.jl
@@ -1,14 +1,10 @@
 
-include("artifacts.jl")
 
-@testset "Read data" begin
 
-    using ACE1pack
+using ACE1pack, Test, LazyArtifacts
 
-    test_train_set = joinpath(artifact"TiAl_tiny_dataset", "TiAl_tiny.xyz")
+test_train_set = joinpath(artifact"TiAl_tiny_dataset", "TiAl_tiny.xyz")
 
-    @info("Test constructing `data_params` and reading data")
-    params = data_params(fname = test_train_set, energy_key = "energy", force_key = "force", virial_key = "virial")
-    data = ACE1pack.read_data(params)
-
-end 
+@info("Test constructing `data_params` and reading data")
+params = data_params(fname = test_train_set, energy_key = "energy", force_key = "force", virial_key = "virial")
+data = ACE1pack.read_data(params)

--- a/test/test_fit.jl
+++ b/test/test_fit.jl
@@ -1,128 +1,123 @@
 
-include("artifacts.jl")
-
-@testset "Fit ACE" begin
-
-    using ACE1pack, JuLIP
-
-    test_train_set = joinpath(artifact"TiAl_tiny_dataset", "TiAl_tiny.xyz")
-    json_params = joinpath(artifact"ACE1pack_test_files", "fit_params.json")
-    expected_errors_json = joinpath(artifact"ACE1pack_test_files", "expected_fit_errors.json")
-    json_params = joinpath(artifact"ACE1pack_test_files", "fit_params.json")
-    yaml_params = joinpath(artifact"ACE1pack_test_files", "fit_params.yaml")
 
 
 
+using ACE1pack, JuLIP, LazyArtifacts, Test
+using JuLIP.Testing: print_tf
 
-    @info("test full fit from script")
+test_train_set = joinpath(artifact"TiAl_tiny_dataset", "TiAl_tiny.xyz")
+json_params = joinpath(artifact"ACE1pack_test_files", "fit_params.json")
+expected_errors_json = joinpath(artifact"ACE1pack_test_files", "expected_fit_errors.json")
+json_params = joinpath(artifact"ACE1pack_test_files", "fit_params.json")
+yaml_params = joinpath(artifact"ACE1pack_test_files", "fit_params.yaml")
 
-    species = [:Ti, :Al]
-    r0 = 2.88 
 
-    data = data_params(fname = test_train_set,
-        energy_key = "energy",
-        force_key = "force",
-        virial_key = "virial")
 
-    rpi_basis = basis_params(
-        type = "rpi",
-        species = species, 
-        N = 3, 
-        maxdeg = 6, 
-        r0 = r0, 
-        rad_basis = basis_params(
-            type = "rad", 
-            rcut = 5.0, 
-            rin = 1.44,
-            pin = 2))
 
-    pair_basis = basis_params(
-        type = "pair", 
-        species = species, 
-        maxdeg = 6,
-        r0 = r0,
-        rcut = 5.0,
-        rin = 0.0,
-        pcut = 2, # TODO: check if it should be 1 or 2?
-        pin = 0)
-    
-    basis = Dict(
-        "rpi_basis" => rpi_basis,
-        "pair_basis" => pair_basis
-    )
+@info("test full fit from script")
 
-    solver = solver_params(solver = :lsqr)
+species = [:Ti, :Al]
+r0 = 2.88 
 
-    # symbols for species (e.g. :Ti) would work as well
-    e0 = Dict("Ti" => -1586.0195, "Al" => -105.5954)
+data = data_params(fname = test_train_set,
+    energy_key = "energy",
+    force_key = "force",
+    virial_key = "virial")
 
-    weights = Dict(
-        "default" => Dict("E" => 5.0, "F" => 1.0, "V" => 1.0),
-        "FLD_TiAl" => Dict("E" => 5.0, "F" => 1.0, "V" => 1.0),
-        "TiAl_T5000" => Dict("E" => 30.0, "F" => 1.0, "V" => 1.0))
+rpi_basis = basis_params(
+    type = "rpi",
+    species = species, 
+    N = 3, 
+    maxdeg = 6, 
+    r0 = r0, 
+    rad_basis = basis_params(
+        type = "rad", 
+        rcut = 5.0, 
+        rin = 1.44,
+        pin = 2))
 
-    P = precon_params(type = "laplacian", rlap_scal = 3.0)
+pair_basis = basis_params(
+    type = "pair", 
+    species = species, 
+    maxdeg = 6,
+    r0 = r0,
+    rcut = 5.0,
+    rin = 0.0,
+    pcut = 2, # TODO: check if it should be 1 or 2?
+    pin = 0)
 
-    params = fit_params(
-        data = data,
-        basis = basis,
-        solver = solver,
-        e0 = e0,
-        weights = weights,
-        P = P,
-        ACE_fname = "")
+basis = Dict(
+    "rpi_basis" => rpi_basis,
+    "pair_basis" => pair_basis
+)
 
-    IP, lsqinfo = ACE1pack.fit_ace(params)
+solver = solver_params(solver = :lsqr)
 
-    errors = lsqinfo["errors"]
+# symbols for species (e.g. :Ti) would work as well
+e0 = Dict("Ti" => -1586.0195, "Al" => -105.5954)
 
-    expected_errors = load_dict(expected_errors_json)
+weights = Dict(
+    "default" => Dict("E" => 5.0, "F" => 1.0, "V" => 1.0),
+    "FLD_TiAl" => Dict("E" => 5.0, "F" => 1.0, "V" => 1.0),
+    "TiAl_T5000" => Dict("E" => 30.0, "F" => 1.0, "V" => 1.0))
 
-    for error_type in keys(errors)
-        for config_type in keys(errors[error_type])
-            for property in keys(errors[error_type][config_type])
-                @test errors[error_type][config_type][property] ≈  
-                expected_errors[error_type][config_type][property]
-            end
-        end
-    end
+P = precon_params(type = "laplacian", rlap_scal = 3.0)
 
-    @info("Test full fit from fit_params.json")
+params = fit_params(
+    data = data,
+    basis = basis,
+    solver = solver,
+    e0 = e0,
+    weights = weights,
+    P = P,
+    ACE_fname = "")
 
-    params = load_dict(json_params)
-    params["data"]["fname"] = test_train_set
-    params["ACE_fname"] = ""
-    params = fill_defaults!(params)
-    IP, lsqinfo = fit_ace(params)
+IP, lsqinfo = ACE1pack.fit_ace(params)
 
-    errors = lsqinfo["errors"]
+errors = lsqinfo["errors"]
 
-    for error_type in keys(errors)
-        for config_type in keys(errors[error_type])
-            for property in keys(errors[error_type][config_type])
-                @test errors[error_type][config_type][property] ≈  
-                expected_errors[error_type][config_type][property]
-            end
-        end
-    end
+expected_errors = load_dict(expected_errors_json)
 
-    @info("Test full fit from fit_params.yaml")
-
-    params = load_dict(yaml_params)
-    params["data"]["fname"] = test_train_set
-    params["ACE_fname"] = ""
-    params = fill_defaults!(params)
-    IP, lsqinfo = fit_ace(params)
-
-    errors = lsqinfo["errors"]
-
-    for error_type in keys(errors)
-        for config_type in keys(errors[error_type])
-            for property in keys(errors[error_type][config_type])
-                @test errors[error_type][config_type][property] ≈  
-                expected_errors[error_type][config_type][property]
-            end
-        end
-    end
-
+for error_type in keys(errors), 
+        config_type in keys(errors[error_type]), 
+            property in keys(errors[error_type][config_type])
+    print_tf(@test errors[error_type][config_type][property] <= 2 * expected_errors[error_type][config_type][property])
 end
+println() 
+
+##
+
+@info("Test full fit from fit_params.json")
+
+params = load_dict(json_params)
+params["data"]["fname"] = test_train_set
+params["ACE_fname"] = ""
+params = fill_defaults!(params)
+IP, lsqinfo = fit_ace(params)
+
+errors = lsqinfo["errors"]
+
+for error_type in keys(errors), 
+    config_type in keys(errors[error_type]), 
+        property in keys(errors[error_type][config_type])
+    print_tf(@test errors[error_type][config_type][property] <= 2 * expected_errors[error_type][config_type][property])
+end
+println() 
+
+##
+@info("Test full fit from fit_params.yaml")
+
+params = load_dict(yaml_params)
+params["data"]["fname"] = test_train_set
+params["ACE_fname"] = ""
+params = fill_defaults!(params)
+IP, lsqinfo = fit_ace(params)
+
+errors = lsqinfo["errors"]
+
+for error_type in keys(errors), 
+    config_type in keys(errors[error_type]), 
+        property in keys(errors[error_type][config_type])
+    print_tf(@test errors[error_type][config_type][property] <= 2 * expected_errors[error_type][config_type][property])
+end
+println() 

--- a/test/test_fit.jl
+++ b/test/test_fit.jl
@@ -5,11 +5,6 @@ include("artifacts.jl")
 
     using ACE1pack, JuLIP
 
-    # test_train_set = joinpath(data_dir, "TiAl_tiny.xyz")
-    # json_params = joinpath(tests_files_dir, "fit_params.json")
-    # expected_errors_json = joinpath(tests_files_dir, "expected_fit_errors.json")
-    # json_params = joinpath(tests_files_dir, "fit_params.json")
-    # yaml_params = joinpath(tests_files_dir, "fit_params.yaml")
     test_train_set = joinpath(artifact"TiAl_tiny_dataset", "TiAl_tiny.xyz")
     json_params = joinpath(artifact"ACE1pack_test_files", "fit_params.json")
     expected_errors_json = joinpath(artifact"ACE1pack_test_files", "expected_fit_errors.json")

--- a/test/test_fit.jl
+++ b/test/test_fit.jl
@@ -1,14 +1,23 @@
 
+include("artifacts.jl")
+
 @testset "Fit ACE" begin
 
     using ACE1pack, JuLIP
 
-    include("artifacts.jl")
-    test_train_set = joinpath(data_dir, "TiAl_tiny.xyz")
-    json_params = joinpath(tests_files_dir, "fit_params.json")
-    expected_errors_json = joinpath(tests_files_dir, "expected_fit_errors.json")
-    json_params = joinpath(tests_files_dir, "fit_params.json")
-    yaml_params = joinpath(tests_files_dir, "fit_params.yaml")
+    # test_train_set = joinpath(data_dir, "TiAl_tiny.xyz")
+    # json_params = joinpath(tests_files_dir, "fit_params.json")
+    # expected_errors_json = joinpath(tests_files_dir, "expected_fit_errors.json")
+    # json_params = joinpath(tests_files_dir, "fit_params.json")
+    # yaml_params = joinpath(tests_files_dir, "fit_params.yaml")
+    test_train_set = joinpath(artifact"TiAl_tiny_dataset", "TiAl_tiny.xyz")
+    json_params = joinpath(artifact"ACE1pack_test_files", "fit_params.json")
+    expected_errors_json = joinpath(artifact"ACE1pack_test_files", "expected_fit_errors.json")
+    json_params = joinpath(artifact"ACE1pack_test_files", "fit_params.json")
+    yaml_params = joinpath(artifact"ACE1pack_test_files", "fit_params.yaml")
+
+
+
 
     @info("test full fit from script")
 

--- a/test/test_read_params.jl
+++ b/test/test_read_params.jl
@@ -1,12 +1,12 @@
+include("artifacts.jl")
 
 @testset "Read params" begin
 
 using ACE1pack, JuLIP
 
-    include("artifacts.jl")
-    test_train_set = joinpath(data_dir, "TiAl_tiny.xyz")
-    json_params_fname = joinpath(tests_files_dir, "fit_params.json")
-    yaml_params_fname = joinpath(tests_files_dir, "fit_params.yaml")
+    test_train_set = joinpath(artifact"TiAl_tiny_dataset", "TiAl_tiny.xyz")
+    json_params_fname = joinpath(artifact"ACE1pack_test_files", "fit_params.json")
+    yaml_params_fname = joinpath(artifact"ACE1pack_test_files", "fit_params.yaml")
 
     data = Dict(
         "energy_key"   => "energy",

--- a/test/test_read_params.jl
+++ b/test/test_read_params.jl
@@ -1,32 +1,29 @@
-include("artifacts.jl")
-
-@testset "Read params" begin
-
-using ACE1pack, JuLIP
-
-    test_train_set = joinpath(artifact"TiAl_tiny_dataset", "TiAl_tiny.xyz")
-    json_params_fname = joinpath(artifact"ACE1pack_test_files", "fit_params.json")
-    yaml_params_fname = joinpath(artifact"ACE1pack_test_files", "fit_params.yaml")
-
-    data = Dict(
-        "energy_key"   => "energy",
-        "fname" => test_train_set,
-        "virial_key"   => "virial")
-
-    @info("Quick test for filling in missing param entries with defaults")
-    data = ACE1pack.fill_defaults!(data, param_key = "data")
-    @test "force_key" in collect(keys(data))
-
-    @info("Test loading params from json")
-    fit_params = load_dict(json_params_fname)
-    fit_params["data"]["fname"] = test_train_set 
-    fit_params = fill_defaults!(fit_params)
-
-    @info("Test loading params from yaml")
-    fit_params = load_dict(yaml_params_fname)
-    fit_params["data"]["fname"] = test_train_set 
-    fit_params = fill_defaults!(fit_params)
 
 
-end
+
+using ACE1pack, Test, JuLIP, LazyArtifacts
+using ACE1.Testing: println_slim
+
+test_train_set = joinpath(artifact"TiAl_tiny_dataset", "TiAl_tiny.xyz")
+json_params_fname = joinpath(artifact"ACE1pack_test_files", "fit_params.json")
+yaml_params_fname = joinpath(artifact"ACE1pack_test_files", "fit_params.yaml")
+
+data = Dict(
+    "energy_key"   => "energy",
+    "fname" => test_train_set,
+    "virial_key"   => "virial")
+
+@info("Quick test for filling in missing param entries with defaults")
+data = ACE1pack.fill_defaults!(data, param_key = "data")
+println_slim(@test "force_key" in collect(keys(data)))
+
+@info("Test loading params from json")
+fit_parms = load_dict(json_params_fname)
+fit_parms["data"]["fname"] = test_train_set 
+fit_parms = fill_defaults!(fit_parms)
+
+@info("Test loading params from yaml")
+fit_parms = load_dict(yaml_params_fname)
+fit_parms["data"]["fname"] = test_train_set 
+fit_parms = fill_defaults!(fit_parms)
 

--- a/test/test_solver.jl
+++ b/test/test_solver.jl
@@ -1,7 +1,7 @@
 
-@testset "Solver" begin
 
-using ACE1pack, JuLIP
+
+using ACE1pack, JuLIP, Test 
 
 @info("Test generating solver params")
 lsqr_damp = 1e-3
@@ -9,5 +9,3 @@ solver = solver_params(solver = :lsqr, lsqr_damp = lsqr_damp)
 solver = ACE1pack.generate_solver(solver)
 @test solver["solver"] == :lsqr
 @test solver["lsqr_damp"] == lsqr_damp
-
-end


### PR DESCRIPTION
The `scripts/generate_artifacts.jl` now updates `Artifacts.toml` based on the tarball hosted at the given (GitHub) link. Whenever the artefact is used in scripts, the same file gets downloaded and decompressed. 

I think the artefact-related problems we had in PR #1 are resolved, but @cortner would you mind running the tests locally to check? 

If all looks good, [ACEData PR #1](https://github.com/ACEsuit/ACEData/pull/1) can be merged. Then I'll update the links here and merge this PR. 