### PR TITLE
Option of multitransform

### DIFF
--- a/src/basis.jl
+++ b/src/basis.jl
@@ -305,8 +305,6 @@ _species_to_params(species::Union{Tuple, AbstractArray}) =
 # values can be anything
 _species_to_params(dict::Dict{Tuple{Tsym, Tsym}, Tval}) where Tsym <: Union{Symbol, AbstractString} where Tval <: Any = 
       Dict(Tuple(_species_to_params(key)) => val for (key, val) in dict)
-      # Dict(_species_to_params(key) => val for (key, val) in dict)
-
 
 _species_to_params(dict::Nothing) = nothing
 
@@ -317,8 +315,6 @@ _params_to_species(species::Union{AbstractArray{T}, Tuple{T, T}}) where T <: Abs
 
 _params_to_species(dict::Dict{Tuple{Tsym, Tsym}, Tval}) where Tsym <: AbstractString where Tval <: Any = 
       Dict(Tuple(_params_to_species(d)) => val for (d, val) in dict)
-# _params_to_species(dict::Dict{Tsym, Tval}) where Tsym <: AbstractArray{<:AbstractString} where Tval <: Any = 
-      # Dict(_params_to_species(d) => val for (d, val) in dict)
 
 _params_to_species(dict::Nothing) = nothing
 

--- a/src/basis.jl
+++ b/src/basis.jl
@@ -273,6 +273,7 @@ end
 
 
 function generate_transform(params::Dict)
+   @assert haskey(_transforms, params["type"])
    TTransform = _transforms[params["type"]][1]
    kwargs = Dict([Symbol(key) => val for (key, val) in params]...)
    delete!(kwargs, :type)

--- a/src/basis.jl
+++ b/src/basis.jl
@@ -3,6 +3,7 @@
 #   ACE Basis  
 
 import ACE1.PairPotentials: PolyPairBasis
+import ACE1.Transforms: PolyTransform, MultiTransform
 
 
 export basis_params, degree_params, transform_params
@@ -124,14 +125,7 @@ end
 function generate_pair_basis(params::Dict)
       species = _params_to_species(params["species"])
       trans = generate_transform(params["transform"])
-      rad_basis = transformed_jacobi(
-            params["maxdeg"],
-            trans, 
-            params["rcut"],
-            params["rin"];
-            pcut = params["pcut"],
-            pin = params["pin"])
-
+      rad_basis = transformed_jacobi(params["maxdeg"], trans, params)
       return PolyPairBasis(rad_basis, species)
 
 end
@@ -141,6 +135,7 @@ end
 
 """
 TODO: needs docs 
+TODO: rcut and rin are ignored for multitransform. 
 """ 
 function rad_basis_params(; 
       r0 = 2.5,
@@ -160,8 +155,7 @@ end
 
 function generate_rad_basis(params::Dict, D, maxdeg, species, trans)
    maxn = ACE1.RPI.get_maxn(D, maxdeg, species)
-   return transformed_jacobi(maxn, trans, params["rcut"], params["rin"];
-                             pcut = params["pcut"], pin = params["pin"] )
+   return transformed_jacobi(maxn, trans, params)
 end
 
 
@@ -174,15 +168,12 @@ _bases = Dict("pair" => (generate_pair_basis, pair_basis_params),
               "rad" => (nothing, rad_basis_params))
 
 
-_species_to_params(species::Union{Symbol, AbstractString}) = 
-      [ string(species), ] 
+transformed_jacobi(maxn::Integer, trans::MultiTransform, params::Dict) = 
+      OrthPolys.transformed_jacobi(maxn, trans; pcut = params["pcut"], pin = params["pin"])
 
-_species_to_params(species::Union{Tuple, AbstractArray}) = 
-      collect( string.(species) )
-
-
-_params_to_species(species::AbstractArray{<: AbstractString}) = 
-      Symbol.(species)
+transformed_jacobi(maxn::Integer, trans::PolyTransform, params::Dict) =
+      OrthPolys.transformed_jacobi(maxn, trans, params["rcut"], params["rin"]; 
+                         pcut = params["pcut"], pin = params["pin"])
 
 
 # ------------------------------------------
@@ -236,15 +227,12 @@ end
 #  this is a little more interesting since there are quite a 
 #  few options. 
 
-# ENH: add multitransform
-
 """
 TODO: needs docs
 """
 function transform_params(; 
       type = "polynomial",
-      kwargs... 
-   )
+      kwargs...)
    @assert haskey(_transforms, type)
    return _transforms[type][2](; kwargs...)
 end
@@ -258,6 +246,29 @@ function PolyTransform_params(; p = 2, r0 = 2.5)
    return Dict("type" => "polynomial", 
                "p" => p, 
                "r0" => r0)
+end
+
+function multitransform_params(; 
+      transforms = nothing,
+      rin = nothing,
+      rcut = nothing,
+      cutoffs=nothing)
+
+      @assert !isnothing(transforms)
+      @assert (!isnothing(rin) && !isnothing(rcut)) || !isnothing(cutoffs)
+
+      return Dict("type" => "multitransform",
+                  "transforms" => _species_to_params(transforms),
+                  "rin" => rin,
+                  "rcut" => rcut,
+                  "cutoffs" => _species_to_params(cutoffs))
+end
+
+function generate_multitransform(; transforms, rin = nothing, rcut = nothing, cutoffs = nothing)
+      transforms = _params_to_species(transforms)
+      transforms = Dict(key => generate_transform(params) for (key, params) in transforms)
+      cutoffs = _params_to_species(cutoffs)
+      return ACE1.Transforms.multitransform(transforms, rin = rin, rcut = rcut, cutoffs = cutoffs)
 end
 
 
@@ -274,5 +285,41 @@ end
 # user supplies for the `type` parameter. The value is a tuple containing 
 # the corresponding transform type and function that generates the defaul 
 # parameters 
-_transforms = Dict( "polynomial" => (ACE1.Transforms.PolyTransform, PolyTransform_params) )
+_transforms = Dict(
+      "polynomial" => (ACE1.Transforms.PolyTransform, PolyTransform_params),
+      "multitransform" => (generate_multitransform, multitransform_params),
+)
+
+
+# ------------------------------------------
+# helper functions
+
+# -- Symbol to string
+_species_to_params(species::Union{Symbol, AbstractString}) = 
+      [ string(species), ] 
+
+_species_to_params(species::Union{Tuple, AbstractArray}) = 
+      collect( string.(species) )
+
+# accept tuples of Symbol or String for dictionary key
+# values can be anything
+_species_to_params(dict::Dict{Tuple{Tsym, Tsym}, Tval}) where Tsym <: Union{Symbol, AbstractString} where Tval <: Any = 
+      Dict(Tuple(_species_to_params(key)) => val for (key, val) in dict)
+      # Dict(_species_to_params(key) => val for (key, val) in dict)
+
+
+_species_to_params(dict::Nothing) = nothing
+
+
+# -- String to Symbol
+_params_to_species(species::Union{AbstractArray{T}, Tuple{T, T}}) where T <: AbstractString  = 
+      Symbol.(species)
+
+_params_to_species(dict::Dict{Tuple{Tsym, Tsym}, Tval}) where Tsym <: AbstractString where Tval <: Any = 
+      Dict(Tuple(_params_to_species(d)) => val for (d, val) in dict)
+# _params_to_species(dict::Dict{Tsym, Tval}) where Tsym <: AbstractArray{<:AbstractString} where Tval <: Any = 
+      # Dict(_params_to_species(d) => val for (d, val) in dict)
+
+_params_to_species(dict::Nothing) = nothing
+
 

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -19,7 +19,7 @@ function fit_ace(params::Dict)
     basis = JuLIP.MLIPs.IPSuperBasis(basis);
 
     if params["fit_from_LSQ_DB"]
-        db = LsqDB(params["LSQ_DB_fname_stem"] * "_kron.h5")
+        db = LsqDB(params["LSQ_DB_fname_stem"])
     else
         db = LsqDB(params["LSQ_DB_fname_stem"], basis, data)
     end

--- a/src/read_params.jl
+++ b/src/read_params.jl
@@ -8,6 +8,8 @@ export  fill_defaults!
 
 """ Recursively updates nested dictionaries with default parameters"""
 function fill_defaults!(params::Dict; param_key = "fit_params")
+    #TODO: "transforms" actually need processing, but it's less straightforward
+    dicts_to_not_process = ["weights", "e0", "transforms", "cutoffs"]
     # Go through the nested dictionaries filling in the default values
     params = _fill_default(params, param_key)
     for (key, val) in params
@@ -15,9 +17,8 @@ function fill_defaults!(params::Dict; param_key = "fit_params")
             for (basis_name, basis_params) in params[key]
                 params[key][basis_name] = fill_defaults!(basis_params; param_key=key)
             end
-        elseif val isa Dict &&  ~(key in ["weights", "e0"])
+        elseif val isa Dict &&  ~(key in dicts_to_not_process)
             params[key] = fill_defaults!(val; param_key = key)
-        elseif key == "basis"
         end
     end
     return params

--- a/test/test_basis.jl
+++ b/test/test_basis.jl
@@ -7,18 +7,51 @@ using ACE1pack, Test
 rpi_basis = basis_params(type="rpi", species = :Si, N = 3, maxdeg = 10)
 ACE1pack.generate_basis(rpi_basis)
 
-@info("Test constructing pair basis and parameters")
-pair_basis = basis_params(type="pair", species = [:Ti, :Al], maxdeg = 6, r0 = 1.2)
-ACE1pack.generate_basis(pair_basis)
 
 @info("Test constructing degree and degree params")
 degree = degree_params()
 D = ACE1pack.generate_degree(degree)
 
-@info("Test constructing tranform and transform parameters")
-trans_params = transform_params(r0 = 1.1)
-transform = ACE1pack.generate_transform(trans_params)
+
+@info("Test constructing tranforms and transform parameters")
+
+# polytransform
+polytransform_params = transform_params(r0 = 1.1)
+transform_poly = ACE1pack.generate_transform(polytransform_params)
+
+#multitransform 
+cutoffs = Dict(
+    (:C, :C) => (1.5, 2.3),
+    (:H, :H) => (0.4, 2.1), 
+    (:C, :H) => (1.2, 3.4))
+
+transforms = Dict(
+    (:C, :C) => transform_params(r0 = 2),
+    (:H, :H) => transform_params(r0 = 1.1),
+    (:C, :H) => transform_params(r0 = 2))
+
+multitransform_params = transform_params(
+    type = "multitransform", 
+    transforms = transforms, 
+    cutoffs = cutoffs)
+
+transform_mult = ACE1pack.generate_transform(multitransform_params)
+
+
+@info("Test constructing pair basis and parameters")
+# with polytransform transform
+pair_basis = basis_params(type="pair", species = [:Ti, :Al], maxdeg = 6, r0 = 1.2)
+ACE1pack.generate_basis(pair_basis)
+
+# with multitransform
+pair_basis = basis_params(type="pair", species = [:Ti, :Al], maxdeg = 6, r0 = 1.2, transform = multitransform_params)
+ACE1pack.generate_basis(pair_basis)
+
 
 @info("Test constructing radial basis parameters and rpi radial basis")
 rad_basis = basis_params(type="rad", rin = 0.0, pin = 0)
-ACE1pack.generate_rad_basis(rad_basis, D, 6, :Si, transform)
+ACE1pack.generate_rad_basis(rad_basis, D, 6, :Si, transform_poly)
+ACE1pack.generate_rad_basis(rad_basis, D, 6, :Si, transform_mult)
+
+
+

--- a/test/test_basis.jl
+++ b/test/test_basis.jl
@@ -52,6 +52,3 @@ ACE1pack.generate_basis(pair_basis)
 rad_basis = basis_params(type="rad", rin = 0.0, pin = 0)
 ACE1pack.generate_rad_basis(rad_basis, D, 6, :Si, transform_poly)
 ACE1pack.generate_rad_basis(rad_basis, D, 6, :Si, transform_mult)
-
-
-


### PR DESCRIPTION
Added a "multitransform" type to `transform_params`. It takes `cutoffs` and `transforms` like so:

```
# Symbols (:C) and strings ("C") work
cutoffs = Dict(
    (:C, :C) => (1.5, 2.3),
    (:H, :H) => (0.4, 2.1), 
    (:C, :H) => (1.2, 3.4))

transforms = Dict(
    (:C, :C) => transform_params(r0 = 2),
    (:H, :H) => transform_params(r0 = 1.1),
    (:C, :H) => transform_params(r0 = 2))

multitransform_params = transform_params(
    type = "multitransform", 
    transforms = transforms, 
    cutoffs = cutoffs)

transform = ACE1pack.generate_transform(multitransform_params)
```
which, since `transform_params` default to "polytransform", is equivalent to 

```
transforms = Dict(
   (:C, :C) => PolyTransform(2, 2),
   (:H, :H) => PolyTransform(2, 1.1),
   (:C, :H) => PolyTransform(2, 2))

cutoffs = Dict(
    (:C, :C) => (1.5, 2.3),
    (:H, :H) => (0.4, 2.1), 
    (:C, :H) => (1.2, 3.4))

transform = ACE1.Transforms.multitransform(transforms, cutoffs=cutoffs)

```