### PR TITLE
Install instructions

### DIFF
--- a/docs/src/gettingstarted/installation.md
+++ b/docs/src/gettingstarted/installation.md
@@ -5,7 +5,7 @@
 
 From the Julia REPL, run: 
 ```julia
-using Pkg; Pkg.activate("."); pkg"registry add https://github.com/JuliaRegistries/General"; pkg"registry add https://github.com/JuliaMolSim/MolSim.git"; pkg"add ACE1pack"
+using Pkg; Pkg.activate("."); pkg"registry add https://github.com/JuliaRegistries/General"; pkg"registry add https://github.com/JuliaMolSim/MolSim.git"; pkg"add ACE1pack, ACE1, JulIP, IPFitting, ASE"
 ```
 
 ## Detailed Instructions
@@ -33,6 +33,8 @@ Now you can install `ACE1pack`. Remaining in the package manager, use
 ```julia
 add ACE1pack
 ```
+
+you will also need to add the following packages: `ACE1, JulIP, IPFitting, ASE`.
 
 ### Returning to a project
 

--- a/docs/src/gettingstarted/installation.md
+++ b/docs/src/gettingstarted/installation.md
@@ -6,18 +6,18 @@
 First, you will need to install julia (see below for instructions). 
 
 Create a folder to hold your julia `ACE` project, and `cd` into the fodler. This folder will track the packages and versions which the `ACE1pack` code requires. For example:
-
 ```
 mkdir ~/ACE1project
 cd ~/ACE1project
 ```
 
-from within this folder type julia to enter the Julia REPL. Then run
+From within this folder type `julia` to enter the Julia REPL. Then run
 ```julia
 using Pkg; Pkg.activate("."); pkg"registry add https://github.com/JuliaRegistries/General"; pkg"registry add https://github.com/JuliaMolSim/MolSim.git"; pkg"add ACE1pack, ACE1, JulIP, IPFitting, ASE"
 ```
 
-from now on, you will need to export the environment variable `JULIA_PROJECT` set to the path to this folder. For example, `export JULIA_PROJECT=~/ACE1project`. You can add this to your `.bashrc`/`.bash_profile` and not touch it again. 
+Before working on an ACE1 project in the `ACE1project` folder you will need to activate the Julia environment you just created in that folder. This can be done by starting julia with `julia --project=pathtoproject`, or from the [package manager](pkg.mk), or by exporting the environment variable `JULIA_PROJECT` set to the path to this folder. For example, `export JULIA_PROJECT=~/ACE1project`. 
+<!-- You can add this to your `.bashrc`/`.bash_profile` and not touch it again.  -->
 
 ## Setting up the Python ASE calculator
 
@@ -29,7 +29,7 @@ python -c "import julia; julia.install()"
 ```
 
 Make sure to use the correct python and pip, e.g. the ones that are in the correct Conda environment.
-Then, to set up PyJulIP:
+Then, to set up `pyjulip`:
 
 ```
 git clone https://github.com/casv2/pyjulip.git

--- a/docs/src/gettingstarted/installation.md
+++ b/docs/src/gettingstarted/installation.md
@@ -24,15 +24,8 @@ from now on, you will need to export the environment variable `JULIA_PROJECT` se
 We use a wrapper called `pyjulip` to call julia and evaluate ACE potentials. In a terminal, with the correct julia project and python environment selected, run the following code:
 
 ```
-git clone https://github.com/JuliaPy/pyjulia.git
-cd pyjulia
 python -m pip install julia
-python
-
->>> from julia.api import Julia
->>> jl = Julia(compiled_modules=False)
->>> import julia
->>> julia.install() # I had to run this before Julia(compiled_modules=False)
+python -c "import julia; julia.install()"
 ```
 
 Make sure to use the correct python and pip, e.g. the ones that are in the correct Conda environment.

--- a/docs/src/gettingstarted/installation.md
+++ b/docs/src/gettingstarted/installation.md
@@ -3,9 +3,45 @@
 
 ## Short Version
 
-From the Julia REPL, run: 
+First, you will need to install julia (see below for instructions). 
+
+Create a folder to hold your julia `ACE` project, and `cd` into the fodler. This folder will track the packages and versions which the `ACE1pack` code requires. For example:
+
+```
+mkdir ~/ACE1project
+cd ~/ACE1project
+```
+
+from within this folder type julia to enter the Julia REPL. Then run
 ```julia
 using Pkg; Pkg.activate("."); pkg"registry add https://github.com/JuliaRegistries/General"; pkg"registry add https://github.com/JuliaMolSim/MolSim.git"; pkg"add ACE1pack, ACE1, JulIP, IPFitting, ASE"
+```
+
+from now on, you will need to export the environment variable `JULIA_PROJECT` set to the path to this folder. For example, `export JULIA_PROJECT=~/ACE1project`. You can add this to your `.bashrc`/`.bash_profile` and not touch it again. 
+
+## Setting up the Python ASE calculator
+
+We use a wrapper called `pyjulip` to call julia and evaluate ACE potentials. In a terminal, with the correct julia project and python environment selected, run the following code:
+
+```
+git clone https://github.com/JuliaPy/pyjulia.git
+cd pyjulia
+python -m pip install julia
+python
+
+>>> from julia.api import Julia
+>>> jl = Julia(compiled_modules=False)
+>>> import julia
+>>> julia.install() # I had to run this before Julia(compiled_modules=False)
+```
+
+Make sure to use the correct python and pip, e.g. the ones that are in the correct Conda environment.
+Then, to set up PyJulIP:
+
+```
+git clone https://github.com/casv2/pyjulip.git
+cd pyjulip
+pip install .
 ```
 
 ## Detailed Instructions

--- a/docs/src/gettingstarted/pkg.md
+++ b/docs/src/gettingstarted/pkg.md
@@ -1,6 +1,6 @@
 # Using the Julia Package Manager
 
-This is a very brief introduction to the [Julia package manager](https://github.com/JuliaLang/Pkg.jl), intended for newcomers to Julia who are here primarily to use the `ACEsuit`. But it is not really ACE specific at all. If you plane to use `ACE1pack.jl` from Python or the command line, then you need not read this.
+This is a very brief introduction to the [Julia package manager](https://github.com/JuliaLang/Pkg.jl), intended for newcomers to Julia who are here primarily to use the `ACEsuit`. But it is not really ACE specific at all. If you plan to use `ACE1pack.jl` from Python or the command line, then you need not read this.
 
 The package manager provides functionality to organize reproducable Julia projects. A project is specified by a `Project.toml` where the user specifies which packages are required, and version bounds on those packages. The Package manager can then *resolve* these dependencies which results in a `Manifest.toml` where the full Julia environment is precisely specified. This can be used in a workflow as follows:
 


### PR DESCRIPTION
added some more info on creating a project folder before the one-liner (otherwise people will just get their `project` and `toml` appearing in random places. Also added the pyjulip instructions into the installation page. 