### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         julia-version:
           - '1.8'
+          - '1'
           - 'nightly'
         python-version: 
           - '3.8'
@@ -60,9 +61,6 @@ jobs:
           using Pkg
           Pkg.precompile()
         shell: bash -c "julia --color=yes {0}"
-      - name: "Add dev ACEfit"
-        run: |
-          julia --project=@. -e 'using Pkg; Pkg.develop("ACEfit")'
       - uses: julia-actions/julia-runtest@v1
 #  test_mpi:
 #    name: Julia MPI ${{ matrix.julia-version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }} x Python ${{ matrix.python-version }}
@@ -136,9 +134,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
-      - run: |
-          # TODO: restore normal ACEfit
-          julia --project=docs -e 'using Pkg; Pkg.develop("ACEfit")'
       - run: |
           julia --project=docs -e '
             using Documenter: DocMeta, doctest

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/Manifest.toml
+*Manifest.toml
 /docs/Manifest.toml
 /docs/build/
 scratch

--- a/Project.toml
+++ b/Project.toml
@@ -36,6 +36,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 [compat]
 ACE1 = "0.11.1, 0.11"
 ACE1x = "0.1"
+ACEfit = "0.1.0"
 ASE = "= 0.5.4"
 JuLIP = "0.13.9, 0.14.0"
 PrettyTables = "1.3, 2.0"

--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,7 @@ YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 [compat]
 ACE1 = "0.11.1, 0.11"
 ACE1x = "0.1"
-ACEfit = "0.1.0"
+ACEfit = "=0.1.0"
 ASE = "= 0.5.4"
 JuLIP = "0.13.9, 0.14.0"
 PrettyTables = "1.3, 2.0"

--- a/test/Artifacts.toml
+++ b/test/Artifacts.toml
@@ -1,0 +1,23 @@
+[ACE1pack_test_files]
+git-tree-sha1 = "9b3562a2b25e2580fe9d16f3ba8d613eddd29dd1"
+lazy = true
+
+    [[ACE1pack_test_files.download]]
+    sha256 = "56290709a859cabac2875804d550e5b088a63644040c6386f504be7b4d17dc82"
+    url = "https://github.com/ACEsuit/ACEData/blob/master/tests/ACE1pack_test_files.tar.gz?raw=true"
+
+[Si_tiny_dataset]
+git-tree-sha1 = "819e985e3a8e8f87dc26139af3389542839706a7"
+lazy = true
+
+    [[Si_tiny_dataset.download]]
+    sha256 = "02c9403b5ab17f07e065065f07dc15e9aaa67867842e4e21304837a325c25e8c"
+    url = "https://github.com/wcwitt/ACEData/blob/master/trainingsets/Si_tiny.tar.gz?raw=true"
+
+[TiAl_tiny_dataset]
+git-tree-sha1 = "86fd99369720539181edb3f27e0a265ae0c696df"
+lazy = true
+
+    [[TiAl_tiny_dataset.download]]
+    sha256 = "3b286227cbd705a7d6f1a695c2decacda9981be588bcc5ce288e479f9e60db5e"
+    url = "https://github.com/ACEsuit/ACEData/blob/master/trainingsets/TiAl_tiny.tar.gz?raw=true"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+JuLIP = "945c410c-986d-556a-acb1-167a618e0462"
+LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,6 @@
 [deps]
+ACE1 = "e3f9bc04-086e-409a-ba78-e9769fe067bb"
+ACE1x = "5cc4c08c-8782-4a30-af6d-550b302e9707"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 JuLIP = "945c410c-986d-556a-acb1-167a618e0462"
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"


### PR DESCRIPTION
This should fix CI, by restricting to ACEfit v0.1.0 #132 @wcwitt 

The main point here is that ACEfit v0.1.1 uses PythonCall. ACE1pack has PyCall dependency, from ASE.jl. PyCall and PythonCall should not be dependecy at the same time, as that will cause problems.

For future we need to either remove or change ASE.jl to use PythonCall and thus remove all PyCall dependencys form ACE1pack.

Also, using `dev` option in CI is a bad idea and I took it off. You can test dev-versions on you local comp, by deving to same environment several packages. You can always register new versions to registry to allow CI to use them as a dep.