### PR TITLE
Adapt to new strategy for recomputing weights

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -212,7 +212,7 @@ function assemble(raw_data, model::ACE1Model;
    end
         
    if weights_only
-      W = recompute_weights(data, model.basis)
+      W = ACEfit.assemble_weights(data)
       return W
    end 
       
@@ -221,22 +221,10 @@ function assemble(raw_data, model::ACE1Model;
 end
 
 
-function __linear_fill!(W, dat, basis; row_start=1)
-   i1 = row_start
-   i2 = row_start + ACEfit.count_observations(dat) - 1
-   W[i1:i2] .= ACEfit.weight_vector(dat)
-   return nothing
-end
-
-function recompute_weights(data::AbstractVector{<: AtomsData}, basis)
-   row_start, row_count = ACEfit.row_info(data)
-   W = zeros(sum(row_count))
-   f = i -> __linear_fill!(W, data[i], basis; row_start=row_start[i])
-   map(f, 1:length(data))
-   return Array(W)
-end
-
-
-function recompute_weights(model::ACE1Model, raw_data; kwargs...)
-   return assemble(raw_data, model; weights_only = true, kwargs...)
+function recompute_weights(raw_data;
+                           energy_key=nothing, force_key=nothing, virial_key=nothing,
+                           weights=Dict("default"=>Dict("E"=>1.0, "F"=>1.0, "V"=>1.0)))
+    data = [ AtomsData(at; energy_key = energy_key, force_key=force_key,
+                   virial_key = virial_key, weights = weights) for at in raw_data ]
+    return ACEfit.assemble_weights(data)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,8 @@ using ACE1pack, Test, LazyArtifacts
 
     @testset "Test silicon" begin include("test_silicon.jl") end
 
+    @testset "Test recomputation of weights" begin include("test_recompw.jl") end
+
 #    @testset "Test ace_fit.jl script" begin include("test_ace_fit.jl") end
 
 end

--- a/test/test_recompw.jl
+++ b/test/test_recompw.jl
@@ -1,26 +1,19 @@
-
-
 using ACE1pack, Test 
-using ACE1pack: linear_assemble
-
-##
 
 @info("Checking recompute_weights")
 
-fname=joinpath(ACE1pack.artifact("Si_tiny_dataset"), "Si_tiny.xyz")
+# generate data
+rawdata = ACE1pack.example_dataset("Si_tiny.xyz")
 datakeys = (energy_key="dft_energy", force_key="dft_force", virial_key="dft_virial")
-rawdata = read_extxyz(fname)
+weights = Dict("default" => Dict("E"=>30.0, "F"=>1.0, "V"=>1.0))
+data = [AtomsData(at; datakeys..., weights = weights) for at in rawdata]
 
-model = acemodel(elements = [:Si,], order = 3, totaldegree = 6);
-
-# standard assembly 
-weights1 = Dict("default" => Dict("E"=>30.0, "F"=>1.0, "V"=>1.0))
-A, Y, W1 = linear_assemble(rawdata, model; weights=weights1, datakeys...)
-
-W2 = ACE1pack.recompute_weights(model, rawdata; weights=weights1, datakeys...)
-
-weights2 = Dict("default" => Dict("E"=>30.0, "F"=>0.1, "V"=>10.0))
-W3 = ACE1pack.recompute_weights(model, rawdata; weights=weights2, datakeys...)
-
+# test recompute weights with identical weights
+W1 = ACEfit.assemble_weights(data)
+W2 = ACE1pack.recompute_weights(rawdata; weights=weights, datakeys...)
 println(@test W1 ≈ W2)
+
+# test recompute_weights with different weights
+weights2 = Dict("default" => Dict("E"=>30.0, "F"=>0.1, "V"=>10.0))
+W3 = ACE1pack.recompute_weights(rawdata; weights=weights2, datakeys...)
 println(@test !(W2 ≈ W3))

--- a/test/test_recompw.jl
+++ b/test/test_recompw.jl
@@ -3,7 +3,7 @@ using ACE1pack, Test
 @info("Checking recompute_weights")
 
 # generate data
-rawdata = ACE1pack.example_dataset("Si_tiny.xyz")
+rawdata, _, _ = ACE1pack.example_dataset("Si_tiny")
 datakeys = (energy_key="dft_energy", force_key="dft_force", virial_key="dft_virial")
 weights = Dict("default" => Dict("E"=>30.0, "F"=>1.0, "V"=>1.0))
 data = [AtomsData(at; datakeys..., weights = weights) for at in rawdata]


### PR DESCRIPTION
Two main things:

* update the test for weight recomputation and add it to runtests (it wasn't actually in the test suite before).
* begin removing some of the temporary hacks in `src/model.jl` related to weight recomputation.

@cortner are you okay with these? Ultimately, I would be happy to refactor the model assembly routine (removing `weights_only`) but wanted to check with you first.