### PR TITLE
Add updated save/load functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
-ACE1 = "0.11.15"
+ACE1 = "0.12"
 ACE1x = "0.1.8"
 ACEfit = "0.1.4"
 ACEmd = "0.1.5"

--- a/Project.toml
+++ b/Project.toml
@@ -13,11 +13,11 @@ JuLIP = "945c410c-986d-556a-acb1-167a618e0462"
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
-
 
 [compat]
 ACE1 = "0.11.15"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -64,6 +64,7 @@ makedocs(;
         "Home" => "index.md",
         "Getting Started" => Any[
             "gettingstarted/installation.md",
+            "gettingstarted/saving-and-loading.md",
             "Tutorials" => Any[
                 "tutorials/index.md",
                 "literate_tutorials/first_example_model.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -59,7 +59,6 @@ makedocs(;
         canonical="https://ACEsuit.github.io/ACEpotentials.jl",
         assets=String[],
     ),
-    strict=true,
     pages=[
         "Home" => "index.md",
         "Getting Started" => Any[

--- a/docs/src/gettingstarted/saving-and-loading.md
+++ b/docs/src/gettingstarted/saving-and-loading.md
@@ -5,7 +5,7 @@
 To save potentials for future Julia use can use
 
 ```julia
-save_ace_potential("my-potential-file.json", potential)
+save_potential("my-potential-file.json", potential)
 ```
 
 This will save the potential in `json` format. You can also use `yml` and `yace` suffixes.
@@ -17,7 +17,7 @@ The format used for saving can be either ACEmodel from `acemodel` function, `JuL
 To load potential use
 
 ```julia
-potential = load_ace_potential("my-potential-file.json")
+potential = load_potential("my-potential-file.json")
 ```
 
 By default this should print information about version in use when the potential was saved. E.g. like following
@@ -33,7 +33,7 @@ ACEmd v0.1.7
 ACEpotentials v0.6.3
 ACEfit v0.1.4
 
-If you have problems with using this potential, pin your installation to above versions.
+If you have problems using this potential, pin your installation to above versions.
 ```
 
 If you have problems with the potential, you can use the given version numbers to build an installation that should have the potential working.
@@ -41,7 +41,7 @@ If you have problems with the potential, you can use the given version numbers t
 By default the loaded potential is in JuLIP style format. To load a new `ACEmd` style `ACEpotential` you can give keyword `new_format=true`
 
 ```julia
-potential = load_ace_potential("my-potential-file.json"; new_format=true)
+potential = load_potential("my-potential-file.json"; new_format=true)
 ```
 
 ## Exporting Potentials for Other Programs

--- a/docs/src/gettingstarted/saving-and-loading.md
+++ b/docs/src/gettingstarted/saving-and-loading.md
@@ -1,0 +1,49 @@
+# Saving and Loading Potentials
+
+## Saving Potentials for Julia use
+
+To save potentials for future Julia use can use
+
+```julia
+save_ace_potential("my-potential-file.json", potential)
+```
+
+This will save the potential in `json` format. You can also use `yml` and `yace` suffixes.
+
+The format used for saving can be either ACEmodel from `acemodel` function, `JuLIP` style potentials or `ACEmd` style `ACEpotential`.
+
+## Loading Potentials
+
+To load potential use
+
+```julia
+potential = load_ace_potential("my-potential-file.json")
+```
+
+By default this should print information about version in use when the potential was saved. E.g. like following
+
+```txt
+This potential was saved with following versions:
+
+JuLIP v0.14.5
+ACEbase v0.4.3
+ACE1x v0.1.8
+ACE1 v0.11.16
+ACEmd v0.1.7
+ACEpotentials v0.6.3
+ACEfit v0.1.4
+
+If you have problems with using this potential, pin your installation to above versions.
+```
+
+If you have problems with the potential, you can use the given version numbers to build an installation that should have the potential working.
+
+By default the loaded potential is in JuLIP style format. To load a new `ACEmd` style `ACEpotential` you can give keyword `new_format=true`
+
+```julia
+potential = load_ace_potential("my-potential-file.json"; new_format=true)
+```
+
+## Exporting Potentials for Other Programs
+
+LAMMPS export is described in section [ACEpotentials potentials in LAMMPS](@ref).

--- a/docs/src/tutorials/TiAl_basis.jl
+++ b/docs/src/tutorials/TiAl_basis.jl
@@ -83,7 +83,7 @@ ACEpotentials.linear_errors(test, pot_2);
 
 # If we want to save the fitted potentials to disk to later use we can use one of the following commands: the first saves the potential as an `ACE1.jl` compatible potential, while the second line exports it to a format that can be ready by the `pacemaker` code to be used within LAMMPS.
 
-save_dict("./TiAl_tutorial_pot.json", Dict("IP" => write_dict(pot_1)))
+save_ace_potential("./TiAl_tutorial_pot.json", pot_1)
 
 # The fitted potential can also be exported to a format compatible with LAMMPS (ML-PACE)
 

--- a/docs/src/tutorials/TiAl_basis.jl
+++ b/docs/src/tutorials/TiAl_basis.jl
@@ -83,7 +83,7 @@ ACEpotentials.linear_errors(test, pot_2);
 
 # If we want to save the fitted potentials to disk to later use we can use one of the following commands: the first saves the potential as an `ACE1.jl` compatible potential, while the second line exports it to a format that can be ready by the `pacemaker` code to be used within LAMMPS.
 
-save_ace_potential("./TiAl_tutorial_pot.json", pot_1)
+save_potential("./TiAl_tutorial_pot.json", pot_1)
 
 # The fitted potential can also be exported to a format compatible with LAMMPS (ML-PACE)
 

--- a/docs/src/tutorials/TiAl_model.jl
+++ b/docs/src/tutorials/TiAl_model.jl
@@ -67,7 +67,7 @@ ACEpotentials.linear_errors(test_data, model; weights=weights);
 
 # If we want to save the fitted potentials to disk to later use we can use one of the following commands: the first saves the potential as an `ACE1.jl` compatible potential, while the second line exports it to a format that can be ready by the `pacemaker` code to be used within LAMMPS.
 
-export2json("./TiAl_tutorial_pot.json", model)
+save_ace_potential("./TiAl_tutorial_pot.json", model)
 
 # export to lammps (ML-PACE):
 

--- a/docs/src/tutorials/TiAl_model.jl
+++ b/docs/src/tutorials/TiAl_model.jl
@@ -67,7 +67,7 @@ ACEpotentials.linear_errors(test_data, model; weights=weights);
 
 # If we want to save the fitted potentials to disk to later use we can use one of the following commands: the first saves the potential as an `ACE1.jl` compatible potential, while the second line exports it to a format that can be ready by the `pacemaker` code to be used within LAMMPS.
 
-save_ace_potential("./TiAl_tutorial_pot.json", model)
+save_potential("./TiAl_tutorial_pot.json", model)
 
 # export to lammps (ML-PACE):
 

--- a/src/ACEpotentials.jl
+++ b/src/ACEpotentials.jl
@@ -12,6 +12,7 @@ include("model.jl")
 include("export.jl")
 include("example_data.jl")
 include("descriptor.jl")
+include("io.jl")
 
 include("analysis/potential_analysis.jl")
 include("analysis/dataset_analysis.jl")

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,0 +1,89 @@
+using Pkg
+
+export load_ace_potential
+export save_ace_potential
+
+"""
+    function load_ace_potential(fname::AbstractString; new_format=false, verbose=true)
+
+Load ACE potential from given file `fname`.
+
+# Kwargs
+- `new_format=false` - If true returns potential as `ACEmd.ACEpotential` format, else use old JuLIP format
+- `verbose=true`     - Display version info on load
+"""
+function load_ace_potential(
+    fname::AbstractString;
+    new_format=false,
+    verbose=true
+)
+    pot_tmp = load_dict(fname)
+    if verbose && haskey(pot_tmp, "Versions")
+        println("\nThis potential was saved with following versions:\n")
+        for (k,v) in pot_tmp["Versions"]
+            n = VersionNumber(v["major"], v["minor"], v["patch"])
+            println(k," v",n)
+        end
+        println("\n", "If you have problems with using this potential, pin your installation to above versions.\n")
+    end
+    if haskey(pot_tmp, "IP")
+        pot = read_dict(pot_tmp["IP"])
+    elseif haskey(pot_tmp, "potential")
+        pot = read_dict(pot_tmp["potential"])
+    else
+        error("Potential format not recognised")
+    end
+    if new_format
+        return ACEpotential(pot.components)
+    else
+        return pot
+    end
+end
+
+
+"""
+    save_ace_potential( fname, potential::ACE1x.ACE1Model; save_version_numbers=true)
+
+Save ACE potentials. Prefix is either .json, .yml or .yace, which also determines file format.
+
+# Kwargs
+- save_version_numbers=true  : If true save version information or relevant packages
+"""
+function save_ace_potential( fname, potential::ACE1x.ACE1Model; save_version_numbers=true)
+    return save_ace_potential(fname, potential.potential; save_version_numbers=save_version_numbers)
+end
+
+function save_ace_potential( fname, potential::ACEmd.ACEpotential; save_version_numbers=true)
+    return save_ace_potential(fname, potential.potentials; save_version_numbers=save_version_numbers)
+end
+
+function save_ace_potential(fname, potential; save_version_numbers=true)
+    if save_version_numbers
+        versions = Dict()
+        versions["ACEpotentials"] = extract_version("ACEpotentials")
+        versions["ACE1"] = extract_version("ACE1")
+        versions["ACE1x"] = extract_version("ACE1x")
+        versions["ACEmd"] = extract_version("ACEmd")
+        versions["ACEbase"] = extract_version("ACEbase")
+        versions["JuLIP"] = extract_version("JuLIP")
+        versions["ACEfit"] = extract_version("ACEfit")
+
+        data = Dict(
+            "IP" => write_dict(potential),
+            "Versions" => versions
+        )
+    else
+        data = Dict(
+            "IP" => write_dict(potential)
+        )
+    end
+    save_dict(fname, data)
+end
+
+
+# used to extraction version numbers when saving
+function extract_version(name::AbstractString)
+    vals = Pkg.dependencies()|> values |> collect
+    hit = filter(x->x.name==name, vals) |> only
+    return hit.version
+end

--- a/src/io.jl
+++ b/src/io.jl
@@ -91,5 +91,5 @@ end
 
 ## Deprecations
 
-@deprecate export2json(fname, model; meta) save_potential(fname, model)
+@deprecate export2json(fname, model; meta=nothing) save_potential(fname, model)
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -42,22 +42,23 @@ end
 
 
 """
-    save_potential( fname, potential::ACE1x.ACE1Model; save_version_numbers=true)
+    save_potential( fname, potential::ACE1x.ACE1Model; save_version_numbers=true, meta=nothing)
 
 Save ACE potentials. Prefix is either .json, .yml or .yace, which also determines file format.
 
 # Kwargs
 - save_version_numbers=true  : If true save version information or relevant packages
+- `meta=nothing`             : Seve some metadata with the potential (needs to be `Dict{String, Any}`)
 """
-function save_potential( fname, potential::ACE1x.ACE1Model; save_version_numbers=true)
-    return save_potential(fname, potential.potential; save_version_numbers=save_version_numbers)
+function save_potential( fname, potential::ACE1x.ACE1Model; save_version_numbers=true, meta=nothing)
+    return save_potential(fname, potential.potential; save_version_numbers=save_version_numbers, meta=meta)
 end
 
-function save_potential( fname, potential::ACEmd.ACEpotential; save_version_numbers=true)
-    return save_potential(fname, potential.potentials; save_version_numbers=save_version_numbers)
+function save_potential( fname, potential::ACEmd.ACEpotential; save_version_numbers=true, meta=nothing)
+    return save_potential(fname, potential.potentials; save_version_numbers=save_version_numbers, meta=meta)
 end
 
-function save_potential(fname, potential; save_version_numbers=true)
+function save_potential(fname, potential; save_version_numbers=true, meta=nothing)
     if save_version_numbers
         versions = Dict()
         versions["ACEpotentials"] = extract_version("ACEpotentials")
@@ -77,6 +78,10 @@ function save_potential(fname, potential; save_version_numbers=true)
             "IP" => write_dict(potential)
         )
     end
+    if !isnothing(meta)
+        @assert isa(meta, Dict{String, <:Any}) "meta needs to be a Dict{String, Any}"
+        data["meta"] = convert(Dict{String, Any}, meta)
+    end
     save_dict(fname, data)
 end
 
@@ -91,5 +96,5 @@ end
 
 ## Deprecations
 
-@deprecate export2json(fname, model; meta=nothing) save_potential(fname, model)
+@deprecate export2json(fname, model; meta=nothing) save_potential(fname, model; meta=meta)
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -87,3 +87,9 @@ function extract_version(name::AbstractString)
     hit = filter(x->x.name==name, vals) |> only
     return hit.version
 end
+
+
+## Deprecations
+
+@deprecate export2json(fname, model; meta) save_potential(fname, model)
+

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,10 +1,10 @@
 using Pkg
 
-export load_ace_potential
-export save_ace_potential
+export load_potential
+export save_potential
 
 """
-    function load_ace_potential(fname::AbstractString; new_format=false, verbose=true)
+    function load_potential(fname::AbstractString; new_format=false, verbose=true)
 
 Load ACE potential from given file `fname`.
 
@@ -12,7 +12,7 @@ Load ACE potential from given file `fname`.
 - `new_format=false` - If true returns potential as `ACEmd.ACEpotential` format, else use old JuLIP format
 - `verbose=true`     - Display version info on load
 """
-function load_ace_potential(
+function load_potential(
     fname::AbstractString;
     new_format=false,
     verbose=true
@@ -42,22 +42,22 @@ end
 
 
 """
-    save_ace_potential( fname, potential::ACE1x.ACE1Model; save_version_numbers=true)
+    save_potential( fname, potential::ACE1x.ACE1Model; save_version_numbers=true)
 
 Save ACE potentials. Prefix is either .json, .yml or .yace, which also determines file format.
 
 # Kwargs
 - save_version_numbers=true  : If true save version information or relevant packages
 """
-function save_ace_potential( fname, potential::ACE1x.ACE1Model; save_version_numbers=true)
-    return save_ace_potential(fname, potential.potential; save_version_numbers=save_version_numbers)
+function save_potential( fname, potential::ACE1x.ACE1Model; save_version_numbers=true)
+    return save_potential(fname, potential.potential; save_version_numbers=save_version_numbers)
 end
 
-function save_ace_potential( fname, potential::ACEmd.ACEpotential; save_version_numbers=true)
-    return save_ace_potential(fname, potential.potentials; save_version_numbers=save_version_numbers)
+function save_potential( fname, potential::ACEmd.ACEpotential; save_version_numbers=true)
+    return save_potential(fname, potential.potentials; save_version_numbers=save_version_numbers)
 end
 
-function save_ace_potential(fname, potential; save_version_numbers=true)
+function save_potential(fname, potential; save_version_numbers=true)
     if save_version_numbers
         versions = Dict()
         versions["ACEpotentials"] = extract_version("ACEpotentials")

--- a/src/model.jl
+++ b/src/model.jl
@@ -176,29 +176,6 @@ function export2lammps(pathtofile, model::ACE1Model)
 end
 
 
-"""
-`export2json(pathtofile, model; meta = Dict())` : exports the fitted potential to a dictionary 
-and then saves that to a JSON or YAML file, depending on the ending in the 
-filename. The dictionary will be of the form 
-```julia
-Dict{String, Any}("potential" => Dict( ... ), "meta" => Dict( ... ) )
-```
-where `potdict` is the dictionary specifies the fitted potential. The `meta` 
-dictionary may contain additional information e.g. about the dataset or the 
-basis or the parameters. Its contents are entirely user specified. 
-"""
-function export2json(pathtofile, model; 
-                     meta = Dict{String, Any}())
-   if !(pathtofile[end-4:end] in [".json", ".yaml"])
-      @warn("the json potential filename should end in .json or .yaml")
-   end
-   potdict = write_dict(model.potential)
-   save_dict(pathtofile, Dict{String, Any}("potential" => potdict, 
-                                               "meta" => meta ))
-end
-
-
-
 # -----------------------------------------------------------
 #  a temporary hack to quickly adapt the training weights \
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using ACEpotentials, Test, LazyArtifacts
 
     @testset "Test silicon" begin include("test_silicon.jl") end
     @testset "Test recomputation of weights" begin include("test_recompw.jl") end
+    @testset "Test IO" begin include("test_io.jl")  end
 
     # outdated
     @testset "Read data" begin include("outdated/test_data.jl") end 

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -30,7 +30,8 @@ weights = Dict("default" => Dict("E"=>30.0, "F"=>1.0, "V"=>1.0),
     )
     fname = tempname() * ".json" 
     pot = ACEpotential(model.potential.components)
-    save_potential(fname, model)
+    @test_throws AssertionError save_potential(fname, model; meta="meta test")
+    save_potential(fname, model; meta=Dict("test"=>"meta test") )
     npot = load_potential(fname; new_format=true)
     @test ace_energy(pot, data[1]) ≈ ace_energy(npot, data[1])
 end

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -30,7 +30,7 @@ weights = Dict("default" => Dict("E"=>30.0, "F"=>1.0, "V"=>1.0),
     )
     fname = tempname() * ".json" 
     pot = ACEpotential(model.potential.components)
-    save_ace_potential(fname, model)
-    npot = load_ace_potential(fname; new_format=true)
+    save_potential(fname, model)
+    npot = load_potential(fname; new_format=true)
     @test ace_energy(pot, data[1]) ≈ ace_energy(npot, data[1])
 end

--- a/test/test_io.jl
+++ b/test/test_io.jl
@@ -1,0 +1,36 @@
+using Test
+using ACEpotentials
+using LazyArtifacts
+
+
+model = acemodel(elements = [:Si],
+                 Eref = [:Si => -158.54496821],
+                 rcut = 5.5,
+                 order = 3,
+                 totaldegree = 12)
+data = read_extxyz(artifact"Si_tiny_dataset" * "/Si_tiny.xyz")
+data_keys = [:energy_key => "dft_energy",
+             :force_key => "dft_force",
+             :virial_key => "dft_virial"]
+weights = Dict("default" => Dict("E"=>30.0, "F"=>1.0, "V"=>1.0),
+               "liq" => Dict("E"=>10.0, "F"=>0.66, "V"=>0.25))
+
+
+@testset "IO for new save and load" begin
+    acefit!(model, data;
+            data_keys...,
+            weights = weights,
+            solver = ACEfit.LSQR(
+                damp = 2e-2,
+                conlim = 1e12, 
+                atol = 1e-7,
+                maxiter = 100000, 
+                verbose = false
+            )
+    )
+    fname = tempname() * ".json" 
+    pot = ACEpotential(model.potential.components)
+    save_ace_potential(fname, model)
+    npot = load_ace_potential(fname; new_format=true)
+    @test ace_energy(pot, data[1]) ≈ ace_energy(npot, data[1])
+end


### PR DESCRIPTION
This is  related to #167 

- Add information about packages to the potential save file
- I made saving simpler - no need to use `write_dict` etc. anymore
- loading is also simpler and has option for `JuLIP` or `ACEmd `styles
- Added a new page on docs for saving and loading.

I am not sure about the names `save_ace_potential` and `load_ace_potential`. But `ACE1` exports `save_potential` and `load_potential`, which are defined in away that makes extending very difficult. And thus I used new names.

The version information saved now should make it possible to build a system where the potential should work. But, this of course will be something that only time will tell.