### PR TITLE
Passes E0 and rin0cuts correctly

### DIFF
--- a/src/models/ace.jl
+++ b/src/models/ace.jl
@@ -87,6 +87,10 @@ function _generate_ace_model(rbasis, Ytype::Symbol, AA_spec::AbstractVector,
                              level = TotalDegree(), 
                              pair_basis = nothing, 
                              E0s = nothing )
+
+   # storing E0s with unit
+   model_meta = Dict{String, Any}("E0s" => deepcopy(E0s))
+
    # generate the coupling coefficients 
    cgen = EquivariantModels.Rot3DCoeffs_real(0)
    AA2BB_map = EquivariantModels._rpi_A2B_matrix(cgen, AA_spec)
@@ -126,9 +130,20 @@ function _generate_ace_model(rbasis, Ytype::Symbol, AA_spec::AbstractVector,
    aa_basis = Polynomials4ML.SparseSymmProdDAG(AA_spec_idx)
    aa_basis.meta["AA_spec"] = AA_spec  # (also store the human-readable spec)
 
+   # process E0s and ustrip any units
    if isnothing(E0s)
       NZ = _get_nz(rbasis)
       E0s = ntuple(i -> 0.0, NZ)
+   elseif E0s isa Dict{Symbol, <: Quantity}
+      NZ = _get_nz(rbasis)
+      _E0s = zeros(NZ)
+      for sym in keys(E0s)
+         idx = findfirst(==(AtomicNumber(sym).z), rbasis._i2z)
+         _E0s[idx] = ustrip(E0s[sym])
+      end
+      E0s = Tuple(_E0s)
+   else
+      error("E0s can either be nothing, or in form of a dictionary with keys 'Symbol' and values 'Uniful.Quantity'.")
    end
 
    tensor = SparseEquivTensor(a_basis, aa_basis, AA2BB_map, 
@@ -136,7 +151,7 @@ function _generate_ace_model(rbasis, Ytype::Symbol, AA_spec::AbstractVector,
 
    return ACEModel(rbasis._i2z, rbasis, ybasis, 
                    tensor, pair_basis, E0s, 
-                   Dict{String, Any}() )
+                   model_meta )
 end
 
 # TODO: it is not entirely clear that the `level` is really needed here 

--- a/src/models/ace.jl
+++ b/src/models/ace.jl
@@ -202,9 +202,9 @@ end
 (l::ACEModel)(args...) = evaluate(l, args...)
 
 function LuxCore.parameterlength(model::ACEModel)
+   # this layer stores the pair basis parameters and the B basis parameters 
    NZ = _get_nz(model)
-   n_B_params, n_AA_params = size(model.A2Bmap)
-   return NZ * n_B_params
+   return NZ^2 * length(model.pairbasis) + NZ * length(model.tensor)
 end
 
 function splinify(model::ACEModel, ps::NamedTuple)

--- a/src/models/ace_heuristics.jl
+++ b/src/models/ace_heuristics.jl
@@ -95,6 +95,7 @@ end
 function ace_model(; elements = nothing, 
                      order = nothing, 
                      Ytype = :solid,  
+                     E0s = nothing,
                      # radial basis 
                      rbasis = nothing, 
                      rbasis_type = :learnable, 
@@ -142,7 +143,7 @@ function ace_model(; elements = nothing,
    AA_spec = sparse_AA_spec(; order = order, r_spec = rbasis.spec, 
                               level = level, max_level = max_level)
 
-   model = ace_model(rbasis, Ytype, AA_spec, level, pair_basis_spl)
+   model = ace_model(rbasis, Ytype, AA_spec, level, pair_basis_spl, E0s)
    model.meta["init_WB"] = String(init_WB)
    model.meta["init_Wpair"] = String(init_Wpair)
 

--- a/src/models/ace_heuristics.jl
+++ b/src/models/ace_heuristics.jl
@@ -96,6 +96,7 @@ function ace_model(; elements = nothing,
                      order = nothing, 
                      Ytype = :solid,  
                      E0s = nothing,
+                     rin0cuts = nothing,
                      # radial basis 
                      rbasis = nothing, 
                      rbasis_type = :learnable, 
@@ -111,12 +112,21 @@ function ace_model(; elements = nothing,
                      init_Wpair = :zeros, 
                      rng = Random.default_rng(), 
                      )
+
+   if rin0cuts == nothing
+      rin0cuts = _default_rin0cuts(elements)
+   else
+      NZ = length(elements)
+      @assert rin0cuts isa SMatrix && size(rin0cuts) == (NZ, NZ)
+   end
+
    # construct an rbasis if needed
    if isnothing(rbasis)
       if rbasis_type == :learnable
          rbasis = ace_learnable_Rnlrzz(; max_level = max_level, level = level, 
                                          maxl = maxl, maxn = maxn, 
-                                         elements = elements)
+                                         elements = elements, 
+                                         rin0cuts = rin0cuts)
       else
          error("unknown rbasis_type = $rbasis_type")
       end

--- a/src/models/sparse.jl
+++ b/src/models/sparse.jl
@@ -2,7 +2,7 @@ using SparseArrays: SparseMatrixCSC
 import Polynomials4ML
 
 
-struct SparseEquivTensor{T, TA, TAA} 
+struct SparseEquivTensor{T, TA, TAA}
    abasis::TA
    aabasis::TAA
    A2Bmap::SparseMatrixCSC{T, Int}

--- a/test/models/test_calculator.jl
+++ b/test/models/test_calculator.jl
@@ -25,8 +25,9 @@ rng = Random.MersenneTwister(1234)
 elements = (:Si, :O)
 level = M.TotalDegree()
 max_level = 15
-order = 3 
-E0s = (-158.54496821, -2042.0330099956639)
+order = 3
+E0s = Dict( :Si => -158.54496821u"eV", 
+            :O => -2042.0330099956639u"eV")
 NZ = length(elements)
 
 function make_rin0cut(zi, zj) 
@@ -47,7 +48,7 @@ model = M.ace_model(; elements = elements, order = order, Ytype = :solid,
 
 ps, st = LuxCore.setup(rng, model)
 
-calc = M.ACEPotential(model, ps, st)
+calc = M.ACEPotential(model, ps, st)   
 
 ##
 
@@ -63,7 +64,7 @@ for ntest = 1:20
    n_O = count(x -> x == 8, AtomsBase.atomic_number(at))
    nlist = PairList(at, M.cutoff_radius(calc))
    efv = M.energy_forces_virial(at, calc, ps_zero, st)
-   print_tf(@test abs(ustrip(efv.energy) - E0s[1] * n_Si - E0s[2] * n_O) < 1e-10)
+   print_tf(@test ustrip(abs(efv.energy - E0s[:Si] * n_Si - E0s[:O] * n_O)) < 1e-10)
 end
 
 println()

--- a/test/models/test_calculator.jl
+++ b/test/models/test_calculator.jl
@@ -57,10 +57,13 @@ ps_zero = _restruct(zero(ps_vec))
 
 for ntest = 1:20
    local Rs, Zs, z0, at, efv 
-   at = AB.rattle!(AB.bulk(:Si, cubic=true) * 2, 0.1)
+   at = AB.randz!( AB.rattle!(AB.bulk(:Si, cubic=true) * 2, 0.1), 
+                   (:Si => 0.6, :O => 0.5), )
+   n_Si = count(x -> x == 14, AtomsBase.atomic_number(at))                   
+   n_O = count(x -> x == 8, AtomsBase.atomic_number(at))
    nlist = PairList(at, M.cutoff_radius(calc))
    efv = M.energy_forces_virial(at, calc, ps_zero, st)
-   print_tf(@test norm(ustrip(efv.energy) - E0s[1] * length(at)) < 1e-10)
+   print_tf(@test abs(ustrip(efv.energy) - E0s[1] * n_Si - E0s[2] * n_O) < 1e-10)
 end
 
 println()


### PR DESCRIPTION
This PR is to pass E0s and rin0cuts to the new ace model argument correctly. Two questions:

- What format do we want to support for passing E0s to `ace_model`? I would imaging sticking to the old format would be the best for compatibility.
- Are there use cases where the pair basis can have different cut off from the many body basis?

