### PR TITLE
Pushforwards

### DIFF
--- a/src/models/Rnl_splines.jl
+++ b/src/models/Rnl_splines.jl
@@ -133,9 +133,9 @@ end
 function rrule(::typeof(evaluate_batched), 
                basis::SplineRnlrzzBasis, 
                rs, zi, zjs, ps, st)
-   Rnl, st = evaluate_batched(basis, rs, zi, zjs, ps, st)
+   Rnl = evaluate_batched(basis, rs, zi, zjs, ps, st)
 
-   return (Rnl, st), 
+   return Rnl, 
          Δ -> (NoTangent(), NoTangent(), NoTangent(), NoTangent(), 
               NamedTuple(), NoTangent())
 end

--- a/src/models/ace.jl
+++ b/src/models/ace.jl
@@ -659,6 +659,15 @@ end
 function evaluate_basis_ed(model::ACEModel, 
                             Rs::AbstractVector{SVector{3, T}}, Zs, Z0, 
                             ps, st) where {T}
+
+   TB = T
+   ∂TB = SVector{3, T}
+   B = zeros(TB, length_basis(model))
+   ∂B = zeros(∂TB, length_basis(model), length(Rs))
+
+   if length(Rs) == 0
+      return B, ∂B
+   end
    
    @no_escape begin 
    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                     
@@ -709,12 +718,8 @@ function evaluate_basis_ed(model::ACEModel,
    # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                     
    end  # @no_escape
 
-   TB = promote_type(eltype(Bmb_i), eltype(B2_i))
-   ∂TB = promote_type(eltype(∂Bmb_i), eltype(∂B2_i))
-   B = zeros(TB, length_basis(model))
    B[get_basis_inds(model, Z0)] .= Bmb_i
    B[get_pairbasis_inds(model, Z0)] .= B2_i
-   ∂B = zeros(∂TB, length_basis(model), size(∂Bmb_i, 2))
    ∂B[get_basis_inds(model, Z0), :] .= ∂Bmb_i
    ∂B[get_pairbasis_inds(model, Z0), :] .= ∂B2_i
 

--- a/test/models/test_ace.jl
+++ b/test/models/test_ace.jl
@@ -162,7 +162,9 @@ for ybasis in [:spherical, :solid]
       print_tf(@test Ei ≈ dot(B, θ))
 
       Ei, ∇Ei = M.evaluate_ed(model, Rs, Zs, z0, ps, st)
-      B, ∇B = M.evaluate_basis_ed(model, Rs, Zs, z0, ps, st)
+
+      B1, ∇B = M.evaluate_basis_ed(model, Rs, Zs, z0, ps, st)
+      print_tf(@test B ≈ B1)
       print_tf(@test ∇Ei ≈ sum(θ .* ∇B, dims=1)[:])   
    end
    println() 
@@ -208,6 +210,25 @@ for ybasis in [:spherical, :solid]
    end
    println() 
 
+## 
+
+   @info("After splinification check correctness of evaluate_basis_ed again")
+   for ntest = 1:10
+      local Nat, Rs, Zs, z0, Ei 
+      Nat = rand(8:16)
+      Rs, Zs, z0 = M.rand_atenv(model, Nat)
+      Us = randn(SVector{3, Float64}, Nat) / sqrt(Nat)
+      B, ∂B = M.evaluate_basis_ed(lin_ace, Rs, Zs, z0, ps, st)
+      B0 = M.evaluate_basis(lin_ace, Rs, Zs, z0, ps, st)
+      ∂B0 = M.jacobian_grad_params(lin_ace, Rs, Zs, z0, ps, st)[3]
+      print_tf(@test B ≈ B0)
+      print_tf(@test ∂B ≈ ∂B0)
+   end
+   println() 
+      # ∂E0 = ForwardDiff.derivative(
+      #       t -> M.evaluate_basis(lin_ace, Rs + t * Us, Zs, z0, ps, st), 
+      #       0.0)
+      
 end
 
 ##

--- a/test/models/test_ace.jl
+++ b/test/models/test_ace.jl
@@ -120,7 +120,7 @@ for ybasis in [:spherical, :solid]
 ##
 
    @info("Test second mixed derivatives reverse-over-reverse")
-   for ntest = 1:20 
+   for ntest = 1:10 
       local Nat, Rs, Zs, Us, Ei, ∂Ei, ∂2_Ei, 
             ps_vec, vs_vec, F, dF0, z0, _restruct 
 
@@ -150,7 +150,7 @@ for ybasis in [:spherical, :solid]
 
    @info("Test basis implementation")
 
-   for ntest = 1:30 
+   for ntest = 1:5 
       local Nat, Rs, Zs, z0, Ei, B, θ, st1 , ∇Ei
 
       Nat = 15
@@ -173,7 +173,7 @@ for ybasis in [:spherical, :solid]
 
    @info("Test the full mixed jacobian")
 
-   for ntest = 1:30 
+   for ntest = 1:5 
       local Nat, Rs, Zs, z0, Ei, ∇Ei, ∂∂Ei, Us, F, dF0
 
       Nat = 15
@@ -195,7 +195,7 @@ for ybasis in [:spherical, :solid]
    ps_lin.WB[:] .= ps.WB[:] 
    ps_lin.Wpair[:] .= ps.Wpair[:]
 
-   for ntest = 1:10
+   for ntest = 1:5
       local len, Nat, Rs, Zs, z0, Ei 
       len = 100 
       mae = sum(1:len) do _
@@ -213,7 +213,7 @@ for ybasis in [:spherical, :solid]
 ## 
 
    @info("After splinification check correctness of evaluate_basis_ed again")
-   for ntest = 1:10
+   for ntest = 1:5
       local Nat, Rs, Zs, z0, Ei 
       Nat = rand(8:16)
       Rs, Zs, z0 = M.rand_atenv(model, Nat)
@@ -225,9 +225,6 @@ for ybasis in [:spherical, :solid]
       print_tf(@test ∂B ≈ ∂B0)
    end
    println() 
-      # ∂E0 = ForwardDiff.derivative(
-      #       t -> M.evaluate_basis(lin_ace, Rs + t * Us, Zs, z0, ps, st), 
-      #       0.0)
       
 end
 

--- a/test/test_silicon.jl
+++ b/test/test_silicon.jl
@@ -49,7 +49,6 @@ rmse_qr = Dict(
     "set"           => Dict("V"=>0.057, "E"=>0.0017, "F"=>0.12),
     "bt"            => Dict("V"=>0.08, "E"=>0.0022, "F"=>0.07),)
 
-
 acefit!(data, model; 
        data_keys...,
        weights = weights,


### PR DESCRIPTION
This PR implements kernels for pushforwards to avoid computing `forces_basis` via AD. Needs another unit test and then those kernels can be integrated. In the future those kernels need to be moved to Polynomials4ML