### PR TITLE
Fix tutorial path string escaping

### DIFF
--- a/ext_tests/tutorial/run_tutorial.jl
+++ b/ext_tests/tutorial/run_tutorial.jl
@@ -8,7 +8,7 @@ appath = abspath(joinpath(@__DIR__(), "..", ".."))
 setuptutorial = """
    begin 
       using Pkg; 
-      Pkg.develop(; path = \"$appath\"); 
+      Pkg.develop(; path = $(repr(appath))); 
       using ACEpotentials; 
       ACEpotentials.copy_tutorial();
    end

--- a/src/json_interface.jl
+++ b/src/json_interface.jl
@@ -197,7 +197,7 @@ function copy_tutorial(dest = pwd())
       orig = joinpath(path, tutfile)
       dest_jl = joinpath(dest, tutfile)
       cp(orig, dest_jl) 
-      jl_script = "using Literate; Literate.notebook(\"$dest_jl\", \"$dest\"; config = Dict(\"execute\" => false))"
+      jl_script = "using Literate; Literate.notebook($(repr(dest_jl)), $(repr(dest)); config = Dict(\"execute\" => false))"
       run(`$julia_cmd --project=$dest -e $jl_script`)
       rm(dest_jl)
    end

--- a/test/test_json.jl
+++ b/test/test_json.jl
@@ -11,10 +11,10 @@ run(`cp $datafile $(tmpproj*"/")`);
 prep_proj = """
    begin 
       using Pkg; 
-      Pkg.activate(\"$tmpproj\"); 
-      Pkg.develop(; path = \"$ap_dir\"); 
+      Pkg.activate($(repr(tmpproj))); 
+      Pkg.develop(; path = $(repr(ap_dir))); 
       using ACEpotentials; 
-      ACEpotentials.copy_runfit(\"$tmpproj\"); 
+      ACEpotentials.copy_runfit($(repr(tmpproj))); 
    end
 """
 run(`$julia_cmd -e $prep_proj`)


### PR DESCRIPTION
Using `repr` here is more reliable if the path contains special characters.

This fixes `copy_tutorial` on Windows.