### PR TITLE
Add AtomsBase v0.5 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ACEpotentials"
 uuid = "3b96b61c-0fcc-4693-95ed-1ef9f35fcc53"
-version = "0.8.6"
+version = "0.8.7"
 
 [deps]
 ACEfit = "ad31a8ef-59f5-4a01-b543-a85c2f73e95c"
@@ -50,14 +50,14 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 ACEfit = "0.2.2"
-AtomsBase = "0.4.1"
+AtomsBase = "0.5"
 AtomsBuilder = "0.2.0"
 AtomsCalculators = "0.2"
 AtomsCalculatorsUtilities = "0.1"
 Bumper = "0.6" 
 ChunkSplitters = "3.0"
 EquivariantModels = "0.0.5"
-ExtXYZ = "0.2.0"
+ExtXYZ = "0.2"
 Interpolations = "0.15"
 PrettyTables = "1.3, 2.0"
 Reexport = "1"

--- a/ext_tests/newkernels/newkernels.jl
+++ b/ext_tests/newkernels/newkernels.jl
@@ -75,7 +75,7 @@ function rand_AlTi(nrep, rattle)
    particles = map( enumerate(at) ) do (i, atom)
       (rand() < 0.5) ? AtomsBase.Atom(22, position(atom)) : atom
    end
-   return FlexibleSystem(particles, bounding_box(at), boundary_conditions(at))      
+   return FlexibleSystem(particles, cell_vectors(at), boundary_conditions(at))      
 end
 
 

--- a/src/analysis/potential_analysis.jl
+++ b/src/analysis/potential_analysis.jl
@@ -181,7 +181,7 @@ function decohesion_curve(at0, pot;
    E0 = potential_energy(at0, pot) / length(at0)
 
    atref = at0 * ntuple(i -> (i == dim ? mult : 1), 3) # (mult, 1, 1) if dim == 1
-   Cref = deepcopy(bounding_box(atref)) 
+   Cref = deepcopy(cell_vectors(atref)) 
    Xref = deepcopy(position(atref, :))
 
    if aa == :auto 
@@ -194,7 +194,7 @@ function decohesion_curve(at0, pot;
 
    function decoh_energy(_a_)
       C = [ deepcopy(Cref)... ]; C[dim] *= (1+_a_)
-      at = AbstractSystem(atref; bounding_box = tuple(C...))
+      at = AbstractSystem(atref; cell_vectors = tuple(C...))
       return potential_energy(at, pot) - length(at) * E0
    end
 


### PR DESCRIPTION
AtomsBase v0.5 changes `bounding_box` → `cell_vectors` but doesn't seem to make any other breaking changes that would affect how ACEpotentials.jl functions. 

Dependency versions resolve but still need to make sure all tests pass too. 


Fixes #297 (in theory). 