### PR TITLE
Fix stable docs not building automatically

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -151,7 +151,7 @@ jobs:
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
       - run: |
           julia --project=docs -e '
             using Documenter: DocMeta, doctest


### PR DESCRIPTION
## Summary
- Uncomment `DOCUMENTER_KEY` in CI workflow to enable stable documentation deployment on tags

## Background
As of v0.10.x, the stable docs weren't building automatically because the `DOCUMENTER_KEY` environment variable was commented out in `.github/workflows/CI.yml`. Without this secret, Documenter.jl cannot push to the `gh-pages` branch when tags are created.

## Changes
- Uncommented line 154 in `.github/workflows/CI.yml` to pass `DOCUMENTER_KEY` to the `julia-docdeploy` action

## Test plan
- [ ] Verify CI documentation job runs successfully on this PR
- [ ] After merge, verify stable docs deploy when a new tag is created

## Note
If the `DOCUMENTER_KEY` secret isn't configured in repository settings, it will need to be set up:
1. Generate SSH key pair
2. Add public key as deploy key (with write access)
3. Add private key as `DOCUMENTER_KEY` secret

Fixes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)