### PR TITLE
Compatibility for PrettyTables v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ACEpotentials"
 uuid = "3b96b61c-0fcc-4693-95ed-1ef9f35fcc53"
-version = "0.10.1"
+version = "0.11.0"
 
 [deps]
 ACEfit = "ad31a8ef-59f5-4a01-b543-a85c2f73e95c"
@@ -80,7 +80,7 @@ Optim = "1"
 Optimisers = "0.3.4, 0.4"
 OrderedCollections = "1"
 Polynomials4ML = "0.5"
-PrettyTables = "1.3, 2"
+PrettyTables = "1.3, 2, 3"
 Reexport = "1"
 Roots = "2"
 SparseArrays = "1"

--- a/examples/Tutorial/ACEpotentials-Tutorial.jl
+++ b/examples/Tutorial/ACEpotentials-Tutorial.jl
@@ -493,7 +493,7 @@ e_table = hcat(
     [e_table_gap[element] for element in elements],
     [e_table_mtp[element] for element in elements])
 println("Energy Error")
-pretty_table(e_table; header = header)
+pretty_table(e_table; column_labels = header)
      
 
 ## create force table
@@ -509,7 +509,7 @@ f_table = hcat(
     [f_table_gap[element] for element in elements],
     [f_table_mtp[element] for element in elements])
 println("Force Error")
-pretty_table(f_table; header = header)
+pretty_table(f_table; column_labels = header)
 
 
 #   ## Part 7: Next steps

--- a/examples/zuobench/error_table.jl
+++ b/examples/zuobench/error_table.jl
@@ -59,10 +59,10 @@ f_table = hcat(string.(syms),
          f_table_gap_mtp)         
 
 println("Energy Error")         
-pretty_table(e_table; header = header)
+pretty_table(e_table; column_labels = header)
 
-println("Force Error")         
-pretty_table(f_table; header = header)
+println("Force Error")
+pretty_table(f_table; column_labels = header)
 
 ##
 

--- a/examples/zuobench/error_table_svd.jl
+++ b/examples/zuobench/error_table_svd.jl
@@ -80,10 +80,10 @@ f_table = hcat(string.(syms),
          f_table_gap_mtp)         
 
 println("Energy Error")         
-pretty_table(e_table; header = header)
+pretty_table(e_table; column_labels = header)
 
-println("Force Error")         
-pretty_table(f_table; header = header)
+println("Force Error")
+pretty_table(f_table; column_labels = header)
 
 ##
 

--- a/examples/zuobench/zuo_asp.jl
+++ b/examples/zuobench/zuo_asp.jl
@@ -80,8 +80,8 @@ f_table = hcat( [ string(sym) ],
 
 
 println("Energy Error (MAE)")
-pretty_table(e_table; header = header)
+pretty_table(e_table; column_labels = header)
 
 println("Force Error (MAE)")
-pretty_table(f_table; header = header)
+pretty_table(f_table; column_labels = header)
 

--- a/src/atoms_data.jl
+++ b/src/atoms_data.jl
@@ -369,9 +369,8 @@ function _print_err_tbl(D::AbstractDict)
     if pkgversion(PrettyTables) >= v"3"
         pretty_table(
             table; column_labels=header,
-            table_format=PrettyTables.TextTableFormat(
-                horizontal_lines_at_data_rows=[length(config_types)-1]),
-            formatters=PrettyTables.fmt__printf("%5.3f"))
+            formatters=[PrettyTables.fmt__printf("%5.3f")],
+        )
     else
         pretty_table(
             table; header=header,

--- a/src/atoms_data.jl
+++ b/src/atoms_data.jl
@@ -366,11 +366,19 @@ function _print_err_tbl(D::AbstractDict)
         [D[c_t]["F"] for c_t in config_types],
         [1000*D[c_t]["V"] for c_t in config_types],
     )
-    pretty_table(
-        table; header=header,
-        body_hlines=[length(config_types)-1],
-        formatters=ft_printf("%5.3f"),
-        crop = :horizontal)
+    if pkgversion(PrettyTables) >= v"3"
+        pretty_table(
+            table; column_labels=header,
+            table_format=PrettyTables.TextTableFormat(
+                horizontal_lines_at_data_rows=[length(config_types)-1]),
+            formatters=PrettyTables.fmt__printf("%5.3f"))
+    else
+        pretty_table(
+            table; header=header,
+            body_hlines=[length(config_types)-1],
+            formatters=ft_printf("%5.3f"),
+            crop = :horizontal)
+    end
 
 end
 
@@ -432,7 +440,14 @@ function assess_dataset(data; kwargs...)
         "missing", 0, 0,
         tot[4]-tot[2], 3*tot[3]-tot[5], 6*tot[2]-tot[6]]
     table = vcat(table, permutedims(tot), permutedims(miss))
-    pretty_table(table; header=header, body_hlines=[length(n_configs)], crop = :horizontal)
+    if pkgversion(PrettyTables) >= v"3"
+        pretty_table(table;
+            column_labels=header,
+            table_format=PrettyTables.TextTableFormat(
+                horizontal_lines_at_data_rows=[length(n_configs)]))
+    else
+        pretty_table(table; header=header, body_hlines=[length(n_configs)], crop = :horizontal)
+    end
 
 end
 


### PR DESCRIPTION
I think it’s pretty funny that a table printing package of all things is causing dependency issues for me when installing ACEpotentials alongside other packages. 

Here’s a fix which uses the newest v3 methods, but keep the existing code available for older versions. 